### PR TITLE
Add FactionsUUID 4.0 support.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,15 @@ allprojects {
         maven(url = "https://repo.tcoded.com/releases")
         maven(url = "https://repo.william278.net/releases")
         maven(url = "https://repo.codemc.org/repository/maven-public")
+        exclusiveContent {
+            forRepository {
+                maven("https://dependency.download/releases")
+            }
+
+            filter {
+                includeGroup("dev.kitteh")
+            }
+        }
     }
 
     java {
@@ -65,6 +74,7 @@ allprojects {
         compileOnly("com.bgsoftware:SuperiorSkyblockAPI:2022.9")
         compileOnly("net.sacredlabyrinth.phaed.simpleclans:SimpleClans:2.15.2")
         compileOnly("com.github.UlrichBR:UClansV7-API:7.13.0-R1")
+        compileOnly("dev.kitteh:factions:4.0.0-rc.1")
 
         compileOnly(files("libs/SternalBoard-2.2.8-all.jar"))
         compileOnly(files("libs/FeatherBoard.jar"))

--- a/src/main/java/fr/maxlego08/koth/hook/TeamPlugin.java
+++ b/src/main/java/fr/maxlego08/koth/hook/TeamPlugin.java
@@ -3,6 +3,7 @@ package fr.maxlego08.koth.hook;
 import fr.maxlego08.koth.KothPlugin;
 import fr.maxlego08.koth.api.KothTeam;
 import fr.maxlego08.koth.hook.teams.BetterTeamHook;
+import fr.maxlego08.koth.hook.teams.FactionsUUIDHook;
 import fr.maxlego08.koth.hook.teams.GangsHook;
 import fr.maxlego08.koth.hook.teams.HuskTownHook;
 import fr.maxlego08.koth.hook.teams.LandHook;
@@ -22,6 +23,7 @@ public enum TeamPlugin {
     SUPERIORSKYBLOCK("SuperiorSkyblock2", SuperiorSkyblock2Hook.class),
     BETTERTEAMS("BetterTeams", BetterTeamHook.class),
     FACTIONS("Factions", SaberFactionHook.class),
+    FACTIONSUUID("FactionsUUID", FactionsUUIDHook.class),
     SIMPLECLANS("SimpleClans", SimpleClanHook.class),
     GANGSPLUS("GangsPlus", GangsHook.class),
     ULTIMATE_CLANS("UltimateClans", UltimateClan.class),

--- a/src/main/java/fr/maxlego08/koth/hook/teams/FactionsUUIDHook.java
+++ b/src/main/java/fr/maxlego08/koth/hook/teams/FactionsUUIDHook.java
@@ -1,0 +1,47 @@
+package fr.maxlego08.koth.hook.teams;
+
+import dev.kitteh.factions.FPlayer;
+import dev.kitteh.factions.FPlayers;
+import dev.kitteh.factions.event.FactionDisbandEvent;
+import fr.maxlego08.koth.KothPlugin;
+import fr.maxlego08.koth.api.KothTeam;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+
+import java.util.List;
+
+public class FactionsUUIDHook implements KothTeam {
+
+    private final KothPlugin plugin;
+
+    public FactionsUUIDHook(KothPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getTeamName(OfflinePlayer player) {
+        return FPlayers.fPlayers().get(player).faction().tag();
+    }
+
+    @Override
+    public List<Player> getOnlinePlayer(OfflinePlayer player) {
+        return FPlayers.fPlayers().get(player).faction().membersOnlineAsPlayers();
+    }
+
+    @Override
+    public String getLeaderName(OfflinePlayer player) {
+        FPlayer fPlayer = FPlayers.fPlayers().get(player).faction().admin();
+        return fPlayer == null ? player.getName() : fPlayer.name();
+    }
+
+    @Override
+    public String getTeamId(OfflinePlayer player) {
+        return String.valueOf(FPlayers.fPlayers().get(player).faction().id());
+    }
+
+    @EventHandler
+    public void onDisband(FactionDisbandEvent event) {
+        this.plugin.getStorageManager().onTeamDisband(String.valueOf(event.getFaction().id()));
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -17,6 +17,7 @@ softdepend:
   - SuperiorSkyblock2
   - LegacyFactions
   - UltimateFactions
+  - FactionsUUID
   - Multiverse-Core
   - SimpleClan
   - zSchedulers


### PR DESCRIPTION
The next update to FactionsUUID breaks away from the historical naming of the plugin as Factions, as there are far too many plugins using the same name with different code. Great opportunity to break lots of API, so this definitely requires its own support. This commit adds such support.